### PR TITLE
Implement simple form management

### DIFF
--- a/includes/class-kontaktform.php
+++ b/includes/class-kontaktform.php
@@ -5,6 +5,7 @@ class Plugin {
     private static $instance;
     public $db_version = '1.0';
     public $table_name;
+    private $forms_option = 'kontaktform_forms';
 
     public static function instance() {
         if ( null === self::$instance ) {
@@ -39,6 +40,7 @@ class Plugin {
         require_once ABSPATH . 'wp-admin/includes/upgrade.php';
         dbDelta( $sql );
         add_option( 'kontaktform_db_version', $this->db_version );
+        add_option( $this->forms_option, array() );
     }
 
     public function register_admin_menu() {
@@ -46,11 +48,80 @@ class Plugin {
     }
 
     public function settings_page() {
-        echo '<div class="wrap"><h1>KontaktForm</h1><p>Formularverwaltung folgt.</p></div>';
+        if ( isset( $_POST['kontaktform_action'] ) && 'add' === $_POST['kontaktform_action'] ) {
+            check_admin_referer( 'kontaktform_add_form' );
+            $name = sanitize_text_field( $_POST['form_name'] );
+            if ( $name ) {
+                $this->add_form( $name );
+                echo '<div class="updated"><p>Formular hinzugefügt.</p></div>';
+            }
+        }
+
+        if ( isset( $_GET['action'], $_GET['form'] ) && 'delete' === $_GET['action'] ) {
+            $form_id = absint( $_GET['form'] );
+            check_admin_referer( 'kontaktform_delete_form_' . $form_id );
+            $this->delete_form( $form_id );
+            echo '<div class="updated"><p>Formular gelöscht.</p></div>';
+        }
+
+        $forms = $this->get_forms();
+
+        echo '<div class="wrap"><h1>KontaktForm</h1>';
+
+        echo '<h2>Formulare</h2>';
+        if ( $forms ) {
+            echo '<table class="widefat"><thead><tr><th>Name</th><th>Shortcode</th><th>Aktionen</th></tr></thead><tbody>';
+            foreach ( $forms as $id => $form ) {
+                $shortcode = '[kontaktform id="' . $id . '"]';
+                $delete_url = wp_nonce_url( admin_url( 'admin.php?page=kontaktform&action=delete&form=' . $id ), 'kontaktform_delete_form_' . $id );
+                echo '<tr><td>' . esc_html( $form['name'] ) . '</td><td><code>' . esc_html( $shortcode ) . '</code></td><td><a href="' . esc_url( $delete_url ) . '">Löschen</a></td></tr>';
+            }
+            echo '</tbody></table>';
+        } else {
+            echo '<p>Keine Formulare vorhanden.</p>';
+        }
+
+        echo '<h2>Neues Formular</h2>';
+        echo '<form method="post">';
+        echo '<input type="hidden" name="kontaktform_action" value="add">';
+        wp_nonce_field( 'kontaktform_add_form' );
+        echo '<p><label for="form_name">Name:</label> <input type="text" id="form_name" name="form_name" required></p>';
+        echo '<p><input type="submit" class="button button-primary" value="Hinzufügen"></p>';
+        echo '</form>';
+
+        echo '</div>';
+    }
+
+    private function get_forms() {
+        $forms = get_option( $this->forms_option, array() );
+        if ( ! is_array( $forms ) ) {
+            $forms = array();
+        }
+        return $forms;
+    }
+
+    private function add_form( $name ) {
+        $forms        = $this->get_forms();
+        $id           = time();
+        $forms[ $id ] = array( 'name' => $name );
+        update_option( $this->forms_option, $forms );
+        return $id;
+    }
+
+    private function delete_form( $id ) {
+        $forms = $this->get_forms();
+        if ( isset( $forms[ $id ] ) ) {
+            unset( $forms[ $id ] );
+            update_option( $this->forms_option, $forms );
+        }
     }
 
     public function render_form_shortcode( $atts ) {
         $atts = shortcode_atts( array( 'id' => 0 ), $atts );
+        $forms = $this->get_forms();
+        if ( empty( $forms[ $atts['id'] ] ) ) {
+            return '';
+        }
         ob_start();
         include plugin_dir_path( __DIR__ ) . 'templates/form.php';
         return ob_get_clean();


### PR DESCRIPTION
## Summary
- add option storage for forms on activation
- implement admin page to list, create and delete forms
- validate shortcode form id

## Testing
- `php -l` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bec842128832ca7b7699f121b2a77